### PR TITLE
Upgrade PusherSwiftWithEncryption to version 9.1.0

### DIFF
--- a/ios/pusher_client.podspec
+++ b/ios/pusher_client.podspec
@@ -19,8 +19,8 @@ A pusher client plugin that works.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'PusherSwiftWithEncryption', '~> 8.0.0'
-  s.platform = :ios, '9.0'
+  s.dependency 'PusherSwiftWithEncryption', '~> 9.1.0'
+  s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
Task [1248 - Update pusher_client packages to version with PrivacyManifest](https://taiga.hackazouk.work/project/official-alumni-mobile/task/1248)
---
- upgrade PusherSwiftWithEncryption to version 9.1.0
  -  PusherSwiftWithEncryption v 9.1.0 depends on `TweetNacl` and `NWWebSocket` instead of `Starscream` and `ReachabilitySwift` [[ref](https://github.com/pusher/pusher-websocket-swift/blob/9.1.0/PusherSwiftWithEncryption.podspec)]